### PR TITLE
Improvements to firstrun procedure

### DIFF
--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -7,6 +7,7 @@ NOCOLOR='\033[0m'
 LIGHTGREEN='\033[1;32m'
 LIGHTCYAN='\033[1;36m'
 LIGHTRED='\033[1;31m'
+YELLOW='\033[1;33m'
 
 if [ -n "${MYSQLHOSTNAME}" ]; then
   # if using external database
@@ -276,9 +277,10 @@ do
   # check to make sure the json is valid.
   if ! jq "." < /tmp/install_process_status_json > /dev/null 2>&1; then
     echo ""
+    echo -e "${YELLOW}WARNING: Invalid JSON returned:${NOCOLOR}"
     cat /tmp/install_process_status_json
     echo ""
-    echo -e "${LIGHTRED}WARNING: Invalid JSON returned, attempting to continue...${NOCOLOR}"
+    echo -e "${YELLOW}Attempting to continue...${NOCOLOR}"
     echo ""
     break
   fi

--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -1,8 +1,6 @@
 #!/usr/bin/with-contenv /bin/bash
 #shellcheck shell=bash
 
-set -x
-
 NOCOLOR='\033[0m'
 LIGHTGREEN='\033[1;32m'
 LIGHTCYAN='\033[1;36m'

--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -277,6 +277,10 @@ do
   cat /tmp/install_process_status_json
   echo ""
 
+  if cat /tmp/install_process_status_json | head -1 | grep '<html>'; then
+    break
+  fi
+
   # Get info from json
   INSTALLERROR=$(jq ".error" < /tmp/install_process_status_json)
   INSTALLNEXT=$(jq ".next" < /tmp/install_process_status_json)

--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -261,8 +261,6 @@ curl "http://127.0.0.1/install/${NEXTLOCATION}" \
 while :
 do
 
-  date
-
   # Get JSON status of install, output to temp file
   curl 'http://127.0.0.1/install/install-action.php' \
     --silent \
@@ -275,18 +273,16 @@ do
     -H 'Connection: keep-alive' \
     --cookie-jar /tmp/install_process_cookies > /tmp/install_process_status_json
 
-  date
-
-  # check to make sure the json is valid
-  if ! jq "." < /tmp/install_process_status_json > /dev/null 2>&1; then
-    echo ""
-    echo -e "${YELLOW}WARNING: Invalid JSON returned:${NOCOLOR}"
-    cat /tmp/install_process_status_json
-    echo ""
-    echo -e "${YELLOW}Attempting to continue...${NOCOLOR}"
-    echo ""
-    break
-  fi
+  # # check to make sure the json is valid
+  # if ! jq "." < /tmp/install_process_status_json > /dev/null 2>&1; then
+  #   echo ""
+  #   echo -e "${YELLOW}WARNING: Invalid JSON returned:${NOCOLOR}"
+  #   cat /tmp/install_process_status_json
+  #   echo ""
+  #   echo -e "${YELLOW}Attempting to continue...${NOCOLOR}"
+  #   echo ""
+  #   break
+  # fi
 
   # Get info from json
   INSTALLERROR=$(jq ".error" < /tmp/install_process_status_json)

--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -332,7 +332,7 @@ html2text /tmp/curl_install_04.log | grep "\* "
 # Initial run of scripts/update_db.php
 echo -e "${LIGHTCYAN}Performing first-run of scripts/update_db.php, this will take a very long time...${NOCOLOR}"
 s6-setuidgid "${WEBUSER}" php /var/www/flightairmap/htdocs/scripts/update_db.php 2>&1 | \
-  awk -W Interactive '! / Parameter must be an array or an object that implements Countable in /'
+  mawk -W Interactive '! / Parameter must be an array or an object that implements Countable in /'
 
 # Stop temporary services
 echo -e "${LIGHTCYAN}  - Stopping temporary services... ${NOCOLOR}"

--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -260,6 +260,9 @@ curl "http://127.0.0.1/install/${NEXTLOCATION}" \
 # Wait for the install to finish...
 while :
 do
+
+  date
+
   # Get JSON status of install, output to temp file
   curl 'http://127.0.0.1/install/install-action.php' \
     --silent \
@@ -272,7 +275,9 @@ do
     -H 'Connection: keep-alive' \
     --cookie-jar /tmp/install_process_cookies > /tmp/install_process_status_json
 
-  # check to make sure the json is valid.
+  date
+
+  # check to make sure the json is valid
   if ! jq "." < /tmp/install_process_status_json > /dev/null 2>&1; then
     echo ""
     echo -e "${YELLOW}WARNING: Invalid JSON returned:${NOCOLOR}"

--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -5,7 +5,7 @@ NOCOLOR='\033[0m'
 LIGHTGREEN='\033[1;32m'
 LIGHTCYAN='\033[1;36m'
 LIGHTRED='\033[1;31m'
-YELLOW='\033[1;33m'
+# YELLOW='\033[1;33m'
 
 if [ -n "${MYSQLHOSTNAME}" ]; then
   # if using external database

--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -273,11 +273,13 @@ do
     -H 'Connection: keep-alive' \
     --cookie-jar /tmp/install_process_cookies > /tmp/install_process_status_json
 
-  echo ""
-  cat /tmp/install_process_status_json
-  echo ""
-
-  if cat /tmp/install_process_status_json | head -1 | grep '<html>'; then
+  # check to make sure the json is valid.
+  if ! jq "." < /tmp/install_process_status_json > /dev/null 2>&1; then
+    echo ""
+    cat /tmp/install_process_status_json
+    echo ""
+    echo -e "${LIGHTRED}WARNING: Invalid JSON returned, attempting to continue...${NOCOLOR}"
+    echo ""
     break
   fi
 

--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -331,7 +331,8 @@ html2text /tmp/curl_install_04.log | grep "\* "
 
 # Initial run of scripts/update_db.php
 echo -e "${LIGHTCYAN}Performing first-run of scripts/update_db.php, this will take a very long time...${NOCOLOR}"
-s6-setuidgid "${WEBUSER}" php /var/www/flightairmap/htdocs/scripts/update_db.php
+s6-setuidgid "${WEBUSER}" php /var/www/flightairmap/htdocs/scripts/update_db.php 2>&1 | \
+  awk -W Interactive '! / Parameter must be an array or an object that implements Countable in /'
 
 # Stop temporary services
 echo -e "${LIGHTCYAN}  - Stopping temporary services... ${NOCOLOR}"

--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -1,6 +1,8 @@
 #!/usr/bin/with-contenv /bin/bash
 #shellcheck shell=bash
 
+set -x
+
 NOCOLOR='\033[0m'
 LIGHTGREEN='\033[1;32m'
 LIGHTCYAN='\033[1;36m'
@@ -270,6 +272,10 @@ do
     -H 'X-Requested-With: XMLHttpRequest' \
     -H 'Connection: keep-alive' \
     --cookie-jar /tmp/install_process_cookies > /tmp/install_process_status_json
+
+  echo ""
+  cat /tmp/install_process_status_json
+  echo ""
 
   # Get info from json
   INSTALLERROR=$(jq ".error" < /tmp/install_process_status_json)

--- a/etc/nginx/conf.d/flightairmap.conf
+++ b/etc/nginx/conf.d/flightairmap.conf
@@ -2,13 +2,13 @@ server {
       listen *:80;
       server_name flightairmap;
       root /var/www/flightairmap/htdocs;
-      proxy_read_timeout 600s;
+      proxy_read_timeout 1200s;
       index index.php index.htm index.html;
       location ~ \.php$ {
            fastcgi_pass 127.0.0.1:9000;
            fastcgi_index index.php;
            include /etc/nginx/fastcgi.conf;
-           fastcgi_read_timeout 600;
+           fastcgi_read_timeout 1200s;
       }
       include /etc/nginx/flightairmap-nginx-conf.include;
 }

--- a/etc/nginx/conf.d/flightairmap.conf
+++ b/etc/nginx/conf.d/flightairmap.conf
@@ -2,12 +2,13 @@ server {
       listen *:80;
       server_name flightairmap;
       root /var/www/flightairmap/htdocs;
+      proxy_read_timeout 600s;
       index index.php index.htm index.html;
       location ~ \.php$ {
            fastcgi_pass 127.0.0.1:9000;
            fastcgi_index index.php;
            include /etc/nginx/fastcgi.conf;
-           fastcgi_read_timeout 300;
+           fastcgi_read_timeout 600;
       }
       include /etc/nginx/flightairmap-nginx-conf.include;
 }


### PR DESCRIPTION
- Increase `proxy_read_timeout` & `fastcgi_read_timeout` settings in `nginx` (fix for issue #8)
- Filter out PHP warnings `PHP Warning: count(): Parameter must be an array or an object that implements Countable in ...`