### PR TITLE
Honor non-standard MySQL port in firstrun checks

### DIFF
--- a/etc/cont-init.d/02-firstrun
+++ b/etc/cont-init.d/02-firstrun
@@ -18,6 +18,7 @@ if [ -n "${MYSQLHOSTNAME}" ]; then
   do
     if mysqladmin \
       --host="${MYSQLHOSTNAME}" \
+      --port="${MYSQLPORT}" \
       --user="${MYSQLUSERNAME}" \
       --password="${MYSQLPASSWORD}" \
       status > /dev/null 2>&1; then
@@ -57,6 +58,7 @@ else
   # if using external database
   NUMTABLES=$(mysqlanalyze \
     --host="${MYSQLHOSTNAME}" \
+    --port="${MYSQLPORT}" \
     --user="${MYSQLUSERNAME}" \
     --password="${MYSQLPASSWORD}" \
     "${MYSQLDATABASE}" | wc -l)


### PR DESCRIPTION
The current version won't work with an MySQL port different from standard port. The user can specify an environment variable MYSQLPORT with the changed port. 
Honor this variable in the database checks in firstrun script.