### PR TITLE
Add ACARS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ ainer cannot be changed, but you are free to use any port on the host side.
 | Container Port | Purpose |
 |----------------|---------|
 | 80 (tcp)       | FlightAirMap application, web server |
+| 9999 (udp)     | [ACARS UDP Messages](https://github.com/valeriosouza/FlightAirMap#acars-only-messages-from-real-flights) |
 
 ## Getting Help
 

--- a/etc/services.d/daemon-acars/run
+++ b/etc/services.d/daemon-acars/run
@@ -1,0 +1,5 @@
+#!/usr/bin/with-contenv sh
+# shellcheck shell=sh
+
+s6-setuidgid "$WEBUSER" php /var/www/flightairmap/htdocs/scripts/daemon-acars.php 2>&1 | awk '{print "[daemon-acars] " $0}'
+


### PR DESCRIPTION
Allows for acarsdec to feed ACARS messages via UDP https://github.com/valeriosouza/FlightAirMap#acars-only-messages-from-real-flights